### PR TITLE
feat(copy): introduce delta mode and byte-based progress (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@
 
 All notable changes to the `rbackup` project will be documented in this file.
 
+## [0.7.0] - 2026-02-23
+
+### ✨ Added
+
+- `-d, --delta` flag for delta-only copy mode.
+- Byte-based progress bar (replaces file-count progress).
+- Advanced `--show-skipped` option with explicit precedence over `--delta`.
+
+### 🔄 Changed
+
+- Default `copy` now shows both copied and skipped items.
+- In `--delta` mode, only copied items are shown by default.
+- Progress bar now reflects:
+    - Total bytes processed (full scan mode)
+    - Total bytes to copy (delta mode)
+- Logging behavior refactored with clear precedence rules:
+    - `--delta` sets implicit `show-skipped=never`
+    - `--show-skipped` explicitly overrides `--delta`
+
+### 🛠 Refactored
+
+- Two-phase copy architecture (plan → execute).
+- Logging context now implements `Default`.
+- `ShowSkipped` now derives `Default` with `#[default]` variant (clippy-clean).
+
+### 🧪 Fixed
+
+- Doctest updated for new `copy_incremental` signature.
+- Resolved `LogContext` missing field errors in tests.
+- Removed duplicate `delta` field in CLI definition.
+
+---
+
 ## [0.6.1] - 2025-10-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.50"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.50"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
 dependencies = [
  "anstream",
  "anstyle",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -299,14 +299,13 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -404,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
@@ -421,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litrs"
@@ -555,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "rbackup"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "clap",
@@ -601,9 +600,9 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -671,24 +670,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -774,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -787,44 +786,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "unicode-ident"
@@ -1201,15 +1198,12 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winresource"
-version = "0.1.23"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcacf11b6f48dd21b9ba002f991bdd5de29b2da8cc2800412f4b80f677e4957"
+checksum = "e287ced0f21cd11f4035fe946fd3af145f068d1acb708afd248100f89ec7432d"
 dependencies = [
  "toml",
  "version_check",
@@ -1220,3 +1214,9 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbackup"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 description = "Incremental, cross-platform and multithreaded backup tool written in Rust"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Important options:
 - `--absolute-exclude` — match exclude patterns against absolute source paths
 - `--ignore-case` — perform case-insensitive matching for exclude patterns
 - `--dry-run` — perform a dry-run without copying files
+- `--show-skipped <never|summary|all>` — control whether skipped items are printed during the run (default: `summary`)
 
 Example:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,8 +3,19 @@
 //! This module defines the clap-powered `Cli` parser and the `Commands` enum
 //! describing the supported subcommands and their options.
 
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
+
+/// Control whether skipped items are printed during the copy.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ShowSkippedArg {
+    /// Never print skipped items.
+    Never,
+    /// Do not print skipped items during the run (only show the final summary).
+    Summary,
+    /// Print both copied and skipped items.
+    All,
+}
 
 /// Parsed command-line arguments for the `rbackup` binary.
 ///
@@ -58,6 +69,10 @@ pub enum Commands {
         /// Destination directory
         destination: PathBuf,
 
+        /// Copy only changed/new items (delta mode). When enabled, skipped items are hidden by default.
+        #[arg(short = 'd', long = "delta", action = ArgAction::SetTrue)]
+        delta: bool,
+
         /// Suppress all output to stdout
         #[arg(short, long, action = ArgAction::SetTrue)]
         quiet: bool,
@@ -94,6 +109,14 @@ pub enum Commands {
             help = "Number of worker threads to use (overrides automatic choice)"
         )]
         jobs: Option<usize>,
+
+        /// Control whether skipped files are printed while copying
+        #[arg(
+            long = "show-skipped",
+            value_enum,
+            help = "(Advanced) Display skipped items: never, summary, or all (overrides --delta default)"
+        )]
+        show_skipped: Option<ShowSkippedArg>,
     },
 
     /// Manage the configuration file (view or edit)

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -67,7 +67,13 @@ fn flush_logger(ctx: &mut LogContext) {
 ///   updated during execution.
 /// - `source`: source directory path.
 /// - `destination`: destination directory path.
-pub fn execute_copy(msg: &Messages, ctx: &mut LogContext, source: &Path, destination: &Path) {
+pub fn execute_copy(
+    msg: &Messages,
+    ctx: &mut LogContext,
+    source: &Path,
+    destination: &Path,
+    delta: bool,
+) {
     let (_cols, rows) = terminal::size().unwrap_or((80, 24));
     let progress_row = rows.saturating_sub(1);
 
@@ -75,7 +81,7 @@ pub fn execute_copy(msg: &Messages, ctx: &mut LogContext, source: &Path, destina
 
     ctx.row = Some(progress_row);
 
-    match copy_incremental(source, destination, msg, ctx) {
+    match copy_incremental(source, destination, msg, ctx, delta) {
         Ok((copied, skipped)) => {
             ctx.row = None;
             ctx.on_log = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod ui;
 pub mod utils;
 
 // Re-exports
-pub use output::LogContext;
+pub use output::{LogContext, ShowSkipped};
 
 /// Thread-safe file logger type: `Arc<Mutex<BufWriter<File>>>`.
 pub use utils::{Logger, Messages, build_exclude_matcher, copy_incremental, is_newer};

--- a/src/output.rs
+++ b/src/output.rs
@@ -42,6 +42,39 @@ pub struct LogContext {
     /// Optional exclude matcher that supports identifying which pattern matched.
     /// See `utils::ExcludeMatcher` for details.
     pub exclude_matcher: Option<crate::utils::ExcludeMatcher>,
+
+    /// Control whether skipped items are printed to the scroll area.
+    ///
+    /// - Never: do not print skipped items.
+    /// - Summary: do not print skipped items during the run (only show the final summary).
+    /// - All: print both copied and skipped items.
+    pub show_skipped: ShowSkipped,
+}
+
+/// Policy for displaying skipped items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ShowSkipped {
+    Never,
+    Summary,
+    #[default]
+    All,
+}
+impl Default for LogContext {
+    fn default() -> Self {
+        Self {
+            logger: None,
+            quiet: false,
+            with_timestamp: false,
+            timestamp_format: None,
+            row: None,
+            on_log: true,
+            exclude_match_absolute: false,
+            dry_run: false,
+            exclude_patterns: None,
+            exclude_matcher: None,
+            show_skipped: ShowSkipped::default(),
+        }
+    }
 }
 
 const DEFAULT_TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S";

--- a/tests/utils_integration.rs
+++ b/tests/utils_integration.rs
@@ -70,18 +70,15 @@ fn test_copy_incremental_integration() {
     let matcher = build_exclude_matcher(&["skip.txt".to_string()], false).unwrap();
 
     let ctx = LogContext {
-        logger: None,
         quiet: true,
-        with_timestamp: false,
         timestamp_format: Some("%Y-%m-%d".into()),
         row: Some(1),
         on_log: false,
-        exclude_match_absolute: false,
-        dry_run: false,
         exclude_matcher: Some(matcher),
-        exclude_patterns: None,
+        ..Default::default()
     };
-    let (copied, skipped) = copy_incremental(src_dir.path(), dst_dir.path(), &msg, &ctx).unwrap();
+    let (copied, skipped) =
+        copy_incremental(src_dir.path(), dst_dir.path(), &msg, &ctx, false).unwrap();
 
     assert_eq!(copied, 1);
     assert_eq!(skipped, 1);
@@ -123,19 +120,16 @@ fn test_copy_incremental_dry_run() {
     };
 
     let ctx = LogContext {
-        logger: None,
         quiet: true,
-        with_timestamp: false,
         timestamp_format: Some("%Y-%m-%d".into()),
         row: Some(1),
         on_log: false,
-        exclude_match_absolute: false,
         dry_run: true,
-        exclude_matcher: None,
-        exclude_patterns: None,
+        ..Default::default()
     };
 
-    let (copied, skipped) = copy_incremental(src_dir.path(), dst_dir.path(), &msg, &ctx).unwrap();
+    let (copied, skipped) =
+        copy_incremental(src_dir.path(), dst_dir.path(), &msg, &ctx, false).unwrap();
 
     assert_eq!(copied, 1);
     assert_eq!(skipped, 0);


### PR DESCRIPTION
feat(copy): introduce --delta mode and byte-based progress (v0.7.0)

- Added --delta flag for delta-only copy
- Switched progress bar from file count to total bytes
- Implemented two-phase plan → execute architecture
- Refined logging precedence between --delta and --show-skipped
- Made ShowSkipped clippy-clean with derived Default
- Fixed doctests and LogContext initialization issues